### PR TITLE
Fix SE collision

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,12 @@
+Version: 0.0.9
+Date: 2021.05.27
+  Bugfixes:
+    - Resolved issue where space buildings were being grounded in space factorissimo factories (Requires latest space exploration version).
+---------------------------------------------------------------------------------------------------
+Version: 0.0.9
+Date: 2021.04.19
+  Info:
+    - Broke something so can't upload 0.0.8 so skipping to 0.0.9
 ---------------------------------------------------------------------------------------------------
 Version: 0.0.8
 Date: 2021.04.19

--- a/collision-mask-util-extended/control/collision-mask-util-control.lua
+++ b/collision-mask-util-extended/control/collision-mask-util-control.lua
@@ -1,0 +1,67 @@
+-- File Licence: You can copy and distribute this file regardless of the mod's general licence. This licence exception does not affect other files of this mod.
+local collision_mask_util_extended = {}
+
+-- see collision_mask_util_extended_extended.lua for full instructions.
+--[[
+-- Example usage
+
+local collision_mask_util_extended = require("collision-mask-util-control")
+function check_collision_layers()
+  collision_mask_util_extended.named_collision_mask_integrity_check()
+  local flying_layer = collision_mask_util_extended.get_named_collision_mask("flying-layer")
+end
+
+script.on_init(check_collision_layers)
+script.on_configuration_changed(check_collision_layers)
+
+function find_flying_entities(surface)
+  local flying_layer = collision_mask_util_extended.get_named_collision_mask("flying-layer")
+  return surface.find_entities_filtered{collision_mask={flying_layer}}
+end
+]]
+
+function collision_mask_util_extended.get_named_collision_mask(mask_name)
+  local prototype = game.entity_prototypes["collision-mask-"..mask_name]
+  if prototype then
+    local layer
+    for mask_name, collides in pairs(prototype.collision_mask) do
+      if layer then
+        error("\n\n\nA reserved collision mask object "..mask_name.." has been compromised by 1 or more of your installed mods. Object must have only 1 collision mask.\n\n")
+      else
+        layer = mask_name
+      end
+    end
+    if not layer then
+      error("\n\n\nA reserved collision mask object "..mask_name.." has been compromised by 1 or more of your installed mods. Object is missing collision_mask.\n\n")
+    end
+    return layer
+  else
+    error("\n\n\nA reserved collision mask object "..mask_name.." has been removed.\n\n")
+  end
+end
+
+function collision_mask_util_extended.named_collision_mask_integrity_check()
+  -- This function will check that collision mask marker objects have 1 collision mask
+  -- Run this on the events: on_init and on_configuration_changed
+  -- It will not detect collision mask marker objects that have been removed from the game
+  -- However: collision_mask_util_extended.get_named_collision_mask(mask_name) will
+  local prototypes = game.get_filtered_entity_prototypes({{filter = "type", type = "arrow"}})
+  for _, prototype in pairs(prototypes) do
+    if string.find(prototype.name, "collision-mask-") then
+      local layer
+      for mask_name, collides in pairs(prototype.collision_mask) do
+        if layer then
+          error("\n\n\nA reserved collision mask object "..mask_name.." has been compromised by 1 or more of your installed mods. Object must have only 1 collision mask.\n\n")
+        else
+          layer = mask_name
+        end
+      end
+      if not layer then
+        error("\n\n\nA reserved collision mask object "..mask_name.." has been compromised by 1 or more of your installed mods. Object is missing collision_mask.\n\n")
+      end
+    end
+  end
+
+end
+
+return collision_mask_util_extended

--- a/collision-mask-util-extended/data/collision-mask-util-extended.lua
+++ b/collision-mask-util-extended/data/collision-mask-util-extended.lua
@@ -1,0 +1,184 @@
+-- File Licence: You can copy and distribute this file regardless of the mod's general licence. This licence exception does not affect other files of this mod.
+local collision_mask_util_extended = require("__core__/lualib/collision-mask-util")
+
+--[[
+
+Named collision masks allow a collision mask to be passed to the control phase.
+The arrow object used to stor the mask is accessible under: game.entity_prototypes["collision-mask-flying-layer"]
+The layer used is therefore: game.entity_prototypes["collision-mask-flying-layer"].collision_mask .. something
+
+--------------------------------------------------------------------------------
+-- INSTRUCTIONS
+--------------------------------------------------------------------------------
+
+-- flying-layer example:
+-- data phase ------------------------------------------------------------------
+(data.lua data-updates.lua data-final-fixes.lua etc) get/make a layer:
+
+-- load the modified util
+local collision_mask_util_extended = require("collision-mask-util-extended")
+
+-- get a collision layer by name, if the name is not assigned to a layer it will assign one
+local flying_layer = collision_mask_util_extended.get_make_named_collision_mask("flying-layer")
+
+-- control phase ---------------------------------------------------------------
+(conrtol.lua) Note: most mods don't need to know collision layers in control code.
+local collision_mask_util_extended = require("collision-mask-util-control")
+
+-- Example usage
+local flying_layer = collision_mask_util_extended.get_named_collision_mask("flying-layer")
+local entities = surface.find_entities_filtered{collision_mask={flying_layer}}
+
+--------------------------------------------------------------------------------
+-- Additional named layers
+--------------------------------------------------------------------------------
+"flying-layer"
+-- local collision_mask_flying_layer = get_make_named_collision_mask("flying-layer")
+Flying vehicles, units, and characters.
+It is useful to also set the mask "not-colliding-with-itself" to prefent air-air collisions.
+The mask can also be added to interior walls that are full height so can't be flown over.
+
+"projectile-layer"
+-- local collision_mask_projectile_layer = get_make_named_collision_mask("projectile-layer")
+Projectiles. The the projectile should have the layers or most things it can hit (flying-layer).
+Walls and shields can also use this layer to block the projectile.
+Note: Projectiles use hit_collision_mask not collision_mask. force_condition = "not-friend" means it won't hit your stuff.
+Note: Streams can't collide.
+
+"vehicle-layer"
+-- local collision_mask_vehicle_layer = get_make_named_collision_mask("vehicle-layer")
+Car type vehicles and things that collide with them. Allows separation of vehicle-layer and player-layer in certain situations. Add to cars, trees, pipes
+
+"space-tile"
+-- local collision_mask_space_tile = get_make_named_collision_mask("space-tile")
+All tiles in space zones (orbit/asteroid fields) including empty space and space platform.
+
+"empty-space-tile"
+-- local collision_mask_empty_space_tile = get_make_named_collision_mask("empty-space-tile")
+tiles in space without flooring.
+Different from void becuase there is no grravity and stuff can float there.
+
+"interior-tile"
+-- local collision_mask_interior_tile = get_make_named_collision_mask("interior-tile")
+Tiles that represent interior spaces and don't have sky, like underground, factory building interiors, etc.
+Rocket silos, artillery, telescopes, and space elevators may not be appropriate here.
+
+"moving-tile"
+-- local collision_mask_moving_tile = get_make_named_collision_mask("moving-tile")
+Tiles that might change surface, such as spaceship tiles or warp structures.
+
+"void-tile"
+-- local collision_mask_void_tile = get_make_named_collision_mask("void-tile")
+Tiles where there is a drop in to the ground (so you can't walk over or build on) but you can fly/jump over.
+
+]]
+local collision_flags =
+{
+  "consider-tile-transitions",
+  "not-colliding-with-itself",
+  "colliding-with-tiles-only"
+}
+collision_mask_util_extended.collision_flags = table.deepcopy(collision_flags)
+
+collision_mask_util_extended.vanilla_named_collision_masks = {
+  ["ground-tile"] = "ground-tile",
+  ["water-tile"] = "water-tile",
+  ["resource-layer"] = "resource-layer",
+  ["doodad-layer"] = "doodad-layer",
+  ["floor-layer"] = "floor-layer",
+  ["item-layer"] = "item-layer",
+  ["ghost-layer"] = "ghost-layer",
+  ["object-layer"] = "object-layer",
+  ["player-layer"] = "player-layer",
+  ["train-layer"] = "train-layer",
+  ["rail-layer"] = "rail-layer",
+  ["transport-belt-layer"] = "transport-belt-layer"
+}
+
+-- fix issue reported in F1.1.5
+collision_mask_util_extended.get_default_mask_vanilla = collision_mask_util_extended.get_default_mask
+collision_mask_util_extended.get_default_mask = function (type)
+  if type == "unit" then
+    return {"player-layer", "train-layer", "not-colliding-with-itself"}
+  else
+    return collision_mask_util_extended.get_default_mask_vanilla(type)
+  end
+end
+
+_named_collision_masks = _named_collision_masks or table.deepcopy(collision_mask_util_extended.vanilla_named_collision_masks) -- do not modify directly
+named_collision_masks = table.deepcopy(_named_collision_masks) -- readonly
+collision_mask_util_extended.named_collision_masks = named_collision_masks
+-- tracks mod layers only. format: named_collision_masks[mask_name] == "layer-"..x
+
+function collision_mask_util_extended.get_named_collision_mask(mask_name)
+  return _named_collision_masks[mask_name]
+end
+
+function collision_mask_util_extended.get_make_named_collision_mask(mask_name)
+  local layer = collision_mask_util_extended.get_named_collision_mask(mask_name)
+  if not layer then
+    layer = collision_mask_util_extended.get_first_unused_layer()
+    log("Named collision layer ["..mask_name .."] set to layer ["..layer.."]")
+    data:extend({
+      {
+        type = "arrow",
+        name = "collision-mask-"..mask_name,
+        collision_mask = {layer},
+        flags = {"placeable-off-grid", "not-on-map"},
+        circle_picture = { filename = "__core__/graphics/empty.png", priority = "low", width = 1, height = 1},
+        arrow_picture = { filename = "__core__/graphics/empty.png", priority = "low", width = 1, height = 1}
+      }
+    })
+  end
+  _named_collision_masks[mask_name] = layer
+  named_collision_masks = table.deepcopy(_named_collision_masks) -- readonly
+  collision_mask_util_extended.named_collision_masks = named_collision_masks
+  return layer
+end
+
+function collision_mask_util_extended.named_collision_mask_integrity_check()
+  -- This function will check that collision mask marker objects have 1 collision mask
+  for mask_name, layer_name in pairs(_named_collision_masks) do
+    if not collision_mask_util_extended.vanilla_named_collision_masks[mask_name] then
+      local mask_bearer = data.raw.arrow["collision-mask-"..mask_name]
+      local layer
+      if mask_bearer then
+        if mask_bearer.collision_mask then
+          for i, mask in pairs(mask_bearer.collision_mask) do
+            if i == 1 then
+              if  mask == "not-colliding-with-itself"
+               or mask == "consider-tile-transitions"
+               or mask == "colliding-with-tiles-only" then
+                error("\n\n\nA reserved collision mask object "..mask_name.." has been compromised by 1 or more of your installed mods. Collision mask must be a collision layer, not a collision option.\n\n")
+              end
+              layer = mask
+            else
+              error("\n\n\nA reserved collision mask object "..mask_name.." has been compromised by 1 or more of your installed mods. Object must have only 1 collision mask.\n\n")
+            end
+          end
+        else
+          error("\n\n\nA reserved collision mask object "..mask_name.." has been compromised by 1 or more of your installed mods. Object is missing collision_mask.\n\n")
+        end
+      else
+        error("\n\n\nA reserved collision mask object "..mask_name.." has been removed.\n\n")
+      end
+    end
+  end
+end
+
+function collision_mask_util_extended.is_mask_empty(mask)
+  for _, layer in pairs(mask) do
+    local is_flag = false
+    for _, option in pairs(collision_flags) do
+      if layer == option then
+        is_flag = true
+      end
+    end
+    if not is_flag then
+      return false
+    end
+  end
+  return true
+end
+
+return collision_mask_util_extended

--- a/control.lua
+++ b/control.lua
@@ -1139,15 +1139,16 @@ local function player_may_enter_factory(player, factory)
 			or settings.global["Factorissimo2-enemy-players-may-enter"].value
 end
 
-local function teleport_entity()
+local function teleport_players()
 	local tick = game.tick
 	for player_index, player in pairs(game.players) do
-		if player.connected and not player.driving and tick - (global.last_player_teleport(player_index) or 0) >= 45 then
+		if player.connected and not player.driving and tick - (global.last_player_teleport[player_index] or 0) >= 45 then
 			local walking_state = player.walking_state
 			if walking_state.walking then
-				if walking_state.direction == defined.direction.north
+				if walking_state.direction == defines.direction.north
 				or walking_state.direction == defines.direction.northeast
 				or walking_state.direction == defines.direction.northwest then
+					-- Enter factory
 					local factory = find_factory_by_building(player.surface, {{player.position.x-0.2, player.position.y-0.3},{player.position.x+0.2, player.position.y}})
 					if factory ~= nil then
 						if math.abs(player.position.x-factory.outside_x)<0.6 then
@@ -1166,9 +1167,9 @@ local function teleport_entity()
 						end
 					end
 				end
-		elseif player.driving and tick - (global.last_player_teleport(player_index) or 0) >= 45
-			log(player.vehicle.name)
+			end
 		end
+	end
 end
 
 -- POWER MANAGEMENT --
@@ -1245,7 +1246,7 @@ script.on_event(defines.events.on_tick, function(event)
 	Connections.update() -- Duh
 
 	-- Teleport players
-	teleport_entity() -- What did you expect
+	teleport_players() -- What did you expect
 
 end)
 

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "space-factorissimo-updated",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "factorio_version": "1.1",
     "title": "Space Factorissimo Updated",
     "author": "Yariazen",

--- a/prototypes/tile.lua
+++ b/prototypes/tile.lua
@@ -11,6 +11,15 @@ local S = "__space-factorissimo-updated__"
 
 alien_biomes_priority_tiles = alien_biomes_priority_tiles or {}
 
+-- COLLISION MASKS
+-- We need to be able to refer to these layers in control.lua so getting a sequential layer from the collision mask util is not ideal
+-- remember to update control.lua setup_collision_layers()
+ -- global scope
+collision_mask_util_extended = require("collision-mask-util-extended/data/collision-mask-util-extended")
+
+-- All space tiles have this
+space_collision_layer = collision_mask_util_extended.get_make_named_collision_mask("space-tile")
+
 local function make_tile(tinfo)
 	table.insert(alien_biomes_priority_tiles, tinfo.name)
 	data:extend({
@@ -79,8 +88,7 @@ end
 
 local function floor_mask()
 	return {
-		"layer-14",
-		"layer-55"
+		space_collision_layer
 	}
 end
 


### PR DESCRIPTION
will have to wait for these changes to `control.lua` to be released on se

```Lua
function is_surface_space(surface)
  local zone = Zone.from_surface(surface)
  if zone and Zone.is_space(zone) then
    return true
  elseif surface and surface.name and string.starts(surface.name, "Space Factory") then
    return true
  end
  return false
end

function on_entity_created(event)
  local entity
  if event.entity and event.entity.valid then
    entity = event.entity
  end
  if event.created_entity and event.created_entity.valid then
    entity = event.created_entity
  end
  if (not entity) or entity.type == "entity-ghost" or entity.type == "tile-ghost" then return end

  if entity.type ~= "deconstructible-tile-proxy" and entity.type ~= "car" and entity.type ~= "spider-vehicle" then
    local area = entity.bounding_box
    local surface = entity.surface
    local proxies = surface.find_entities_filtered{area = area, type = "deconstructible-tile-proxy"}
    for _, proxy in pairs(proxies) do
      proxy.destroy()
    end
  end

  if is_surface_space(entity.surface) then
    if (entity.type == "car")
      and (not string.find(entity.name, mod_prefix.."space", 1, true))
      and entity.prototype.effectivity > 0 then
      return cancel_entity_creation(entity, event.player_index, {"space-exploration.construction-denied-vehicle-in-space"})
    end
    if game.entity_prototypes[entity.name..name_suffix_spaced] then
      -- replace with spaced
      return swap_structure(entity, entity.name..name_suffix_spaced)
    end
    if string.find(entity.name, name_suffix_grounded, 1, true) then
      -- replace with non-grounded
      return swap_structure(entity, util.replace(entity.name, name_suffix_grounded, ""))
    end
    if entity.type == "offshore-pump" then
      return cancel_entity_creation(entity, event.player_index, {"space-exploration.construction-denied"})
    end
  else -- not space
    if string.find(entity.name, name_suffix_spaced, 1, true) then
      -- replace with non-spaced
      return swap_structure(entity, util.replace(entity.name, name_suffix_spaced, ""))
    end
    if game.entity_prototypes[entity.name..name_suffix_grounded] then
      -- replace with grounded
      return swap_structure(entity, entity.name..name_suffix_grounded)
    end
    if zone and entity.name == "kr-atmospheric-condenser" and (not zone.is_homeworld) and zone.tags and util.table_contains(zone.tags, "water_none") then
      return cancel_entity_creation(entity, event.player_index, {"space-exploration.construction-denied-no-water"})
    end
    if zone and entity.type == "offshore-pump" and (not zone.is_homeworld) and zone.tags and util.table_contains(zone.tags, "water_none") then
      if entity.prototype.fluid == "water" then -- there is no water on this planet, send via rocket, cannon, or ship
        return cancel_entity_creation(entity, event.player_index, {"space-exploration.construction-denied-no-water"})
      end
    end
  end

end
Event.addListener(defines.events.on_robot_built_entity, on_entity_created)
Event.addListener(defines.events.on_built_entity, on_entity_created)
Event.addListener(defines.events.script_raised_built, on_entity_created)
Event.addListener(defines.events.script_raised_revive, on_entity_created)
```